### PR TITLE
Migrated all projects targeting .NET 9.0

### DIFF
--- a/BenchmarkProfiling/BenchmarkProfiling.csproj
+++ b/BenchmarkProfiling/BenchmarkProfiling.csproj
@@ -1,66 +1,14 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{7507D8DD-E4DF-412B-A411-C225E3443CCE}</ProjectGuid>
+    <TargetFramework>net9.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>BenchmarkProfiling</RootNamespace>
-    <AssemblyName>BenchmarkProfiling</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <AssemblyTitle>BenchmarkProfiling</AssemblyTitle>
+    <Product>BenchmarkProfiling</Product>
+    <Copyright>Copyright ©  2017</Copyright>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <FileVersion>1.0.0.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
+    <ProjectReference Include="..\OcfLzw2\OcfLzw2.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Program.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="App.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\OcfLzw2\OcfLzw2.csproj">
-      <Project>{76d25c7f-bd56-44e6-87ed-fe866ea63ace}</Project>
-      <Name>OcfLzw2</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/BenchmarkProfiling/Properties/AssemblyInfo.cs
+++ b/BenchmarkProfiling/Properties/AssemblyInfo.cs
@@ -1,16 +1,6 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("BenchmarkProfiling")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("BenchmarkProfiling")]
-[assembly: AssemblyCopyright("Copyright ©  2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -21,16 +11,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("7507d8dd-e4df-412b-a411-c225e3443cce")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/DecodeTesting/DecodeTesting.csproj
+++ b/DecodeTesting/DecodeTesting.csproj
@@ -1,93 +1,19 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{23A2EC9F-45EA-4C79-BE8E-96B2D13E844A}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>DecodeTesting</RootNamespace>
-    <AssemblyName>DecodeTesting</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
-    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
-    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
-    <IsCodedUITest>False</IsCodedUITest>
-    <TestProjectType>UnitTest</TestProjectType>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsTestProject>true</IsTestProject>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="System" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.5.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.5.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
   </ItemGroup>
-  <Choose>
-    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-      </ItemGroup>
-    </When>
-    <Otherwise>
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
-      </ItemGroup>
-    </Otherwise>
-  </Choose>
+
   <ItemGroup>
-    <Compile Include="UnitTest1.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
+    <ProjectReference Include="..\OcfLzw2\OcfLzw2.csproj" />
+    <ProjectReference Include="..\OcfLzw\OcfLzw.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\OcfLzw2\OcfLzw2.csproj">
-      <Project>{76d25c7f-bd56-44e6-87ed-fe866ea63ace}</Project>
-      <Name>OcfLzw2</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\OcfLzw\OcfLzw.csproj">
-      <Project>{b70171ca-7bb4-425a-9dcf-290d4719389d}</Project>
-      <Name>OcfLzw</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <Choose>
-    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-      </ItemGroup>
-    </When>
-  </Choose>
-  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/DecodeTesting/Properties/AssemblyInfo.cs
+++ b/DecodeTesting/Properties/AssemblyInfo.cs
@@ -1,16 +1,6 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("DecodeTesting")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("DecodeTesting")]
-[assembly: AssemblyCopyright("Copyright ©  2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -21,16 +11,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("23a2ec9f-45ea-4c79-be8e-96b2d13e844a")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/OcfLzw/LzwDictionary.cs
+++ b/OcfLzw/LzwDictionary.cs
@@ -1,148 +1,140 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace OcfLzw
+namespace OcfLzw;
+
+public class LzwDictionary : Dictionary<long, byte[]>
 {
-    public class LzwDictionary : Dictionary<long, byte[]>
+    private long nextCode = 258; // Next code value
+    private int codeSize = 9; // Default code size ...
+
+    // Set our buffer size to prevent having to reallocate the memory over and over
+    private MemoryStream buffer = new(9029);
+
+    /// <summary>
+    /// This is the used for the LZWDecode filter.  This represents the dictionary mappings
+    /// between codes and their values.
+    /// </summary>
+    /// <remarks>
+    public LzwDictionary(int size) : base(size)
     {
-        private long nextCode = 258; // Next code value
-        private int codeSize = 9; // Default code size ...
+        Root = new LzwNode();
 
-        // Set our buffer size to prevent having to reallocate the memory over and over
-        private MemoryStream buffer = new MemoryStream(9029);
-
-        /// <summary>
-        /// This is the used for the LZWDecode filter.  This represents the dictionary mappings
-        /// between codes and their values.
-        /// </summary>
-        /// <remarks>
-        public LzwDictionary(int size) : base(size)
+        for (long i = 0; i < 256; i++)
         {
-            Root = new LzwNode();
-            
-            for (long i = 0; i < 256; i++)
+            LzwNode node = new()
             {
-                LzwNode node = new LzwNode();
-                node.Code = i;
-                this.Root.SetNode((byte)i, node);
-                this.Add(i, new byte[] { (byte)i });
+                Code = i
+            };
+            this.Root.SetNode((byte)i, node);
+            this.Add(i, [(byte)i]);
+        }
+    }
+
+    public LzwNode Root { get; set; }
+
+    /// <summary>
+    /// This will get the value for the code. It will return null if the code is not
+    /// defined.
+    /// </summary>
+    /// <param name="code">The key to the data.</param>
+    /// <returns>The data that is mapped to the code.</returns>
+    public byte[] GetData(long code)
+    {
+        this.TryGetValue(code, out byte[] data);
+        return data;
+    }
+
+    /// <summary>
+    /// This will take a visit from a byte[].  This will create new code entries as
+    /// necessary.
+    /// </summary>
+    /// <param name="data">The bytes to get a visit from.</param>
+    public void Visit(byte[] data)
+    {
+        for (int i = 0; i < data.Length; i++)
+        {
+            this.Visit(data[i]);
+        }
+    }
+
+    /// <summary>
+    /// This will take a visit from a byte.  This will create new code entries as
+    /// necessary.
+    /// </summary>
+    /// <param name="data">The byte to get a visit from.</param>
+    public void Visit(byte data)
+    {
+        buffer.WriteByte(data);
+        byte[] curBuffer = buffer.ToArray();
+        LzwNode current = this.Root;
+
+        bool createNewCode = false;
+
+        for (int i = 0; i < curBuffer.Length && current != null; i++)
+        {
+            LzwNode previous = current;
+            current = current.GetNode(curBuffer[i]);
+            if (current == null)
+            {
+                createNewCode = true;
+                current = new LzwNode();
+                previous.SetNode(curBuffer[i], current);
             }
         }
 
-        public LzwNode Root { get; set; }
-
-        /// <summary>
-        /// This will get the value for the code. It will return null if the code is not
-        /// defined.
-        /// </summary>
-        /// <param name="code">The key to the data.</param>
-        /// <returns>The data that is mapped to the code.</returns>
-        public byte[] GetData(long code)
+        if (createNewCode)
         {
-            byte[] data;
-            this.TryGetValue(code, out data);
-            return data;
-        }
+            long code = nextCode++;
+            current.Code = code;
+            this.Add(code, curBuffer);
 
-        /// <summary>
-        /// This will take a visit from a byte[].  This will create new code entries as
-        /// necessary.
-        /// </summary>
-        /// <param name="data">The bytes to get a visit from.</param>
-        public void Visit(byte[] data) 
-        {
-            for( int i = 0; i<data.Length; i++ )
-            {
-                this.Visit(data[i] );
-            }
-        }
-
-        /// <summary>
-        /// This will take a visit from a byte.  This will create new code entries as
-        /// necessary.
-        /// </summary>
-        /// <param name="data">The byte to get a visit from.</param>
-        public void Visit(byte data)
-        {
-            buffer.WriteByte(data);
-            byte[] curBuffer = buffer.ToArray();
-
-            LzwNode previous = null;
-            LzwNode current = this.Root;
-
-            bool createNewCode = false;
-
-            for (int i = 0; i < curBuffer.Length && current != null; i++)
-            {
-                previous = current;
-                current = current.GetNode(curBuffer[i]);
-                if (current == null)
-                {
-                    createNewCode = true;
-                    current = new LzwNode();
-                    previous.SetNode(curBuffer[i], current);
-                }
-            }   
-
-            if (createNewCode)
-            {
-                long code = nextCode++;
-                current.Code = code;
-                this.Add(code, curBuffer);
-
-                buffer = new MemoryStream();
-                buffer.WriteByte(data);
-                resetCodeSize();
-
-            }
-        }
-
-       
-        
-       /// <summary>
-       /// This will determine the code size.
-       /// </summary>
-        private void resetCodeSize()
-        {
-            if (nextCode >= 2048)
-            {
-                codeSize = 12;
-            }
-            else if (nextCode >= 1024)
-            {
-                codeSize = 11;
-            }
-            else if (nextCode >= 512)
-            {
-                codeSize = 10;
-            }
-            else
-            {
-                codeSize = 9;
-            }
-        }
-
-        /// <summary>
-        /// This will crear the internal buffer that the dictionary uses.
-        /// </summary>
-        public void Clearbuffer()
-        {
             buffer = new MemoryStream();
-        }
+            buffer.WriteByte(data);
+            ResetCodeSize();
 
-        /// <summary>
-        /// This will get the next code that will be created.
-        /// </summary>
-        /// <returns></returns>
-        public long GetNextCode()
-        {
-            return nextCode;
         }
     }
 
 
+
+    /// <summary>
+    /// This will determine the code size.
+    /// </summary>
+    private void ResetCodeSize()
+    {
+        if (nextCode >= 2048)
+        {
+            codeSize = 12;
+        }
+        else if (nextCode >= 1024)
+        {
+            codeSize = 11;
+        }
+        else if (nextCode >= 512)
+        {
+            codeSize = 10;
+        }
+        else
+        {
+            codeSize = 9;
+        }
+    }
+
+    /// <summary>
+    /// This will crear the internal buffer that the dictionary uses.
+    /// </summary>
+    public void Clearbuffer()
+    {
+        buffer = new MemoryStream();
+    }
+
+    /// <summary>
+    /// This will get the next code that will be created.
+    /// </summary>
+    /// <returns></returns>
+    public long GetNextCode()
+    {
+        return nextCode;
+    }
 }

--- a/OcfLzw/LzwNode.cs
+++ b/OcfLzw/LzwNode.cs
@@ -1,55 +1,48 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
-namespace OcfLzw
+namespace OcfLzw;
+
+/// <summary>
+/// Lzw Node for the node tree. I think this is incredibly memory inefficient.
+/// Need to look at just using some linked lists instead
+/// </summary>
+public class LzwNode
 {
-    /// <summary>
-    /// Lzw Node for the node tree. I think this is incredibly memory inefficient.
-    /// Need to look at just using some linked lists instead
-    /// </summary>
-    public class LzwNode
+
+    private readonly Dictionary<byte, LzwNode> subNodes = [];
+
+    public LzwNode()
     {
-        
-        private Dictionary<byte, LzwNode> subNodes = new Dictionary<byte, LzwNode>();
 
-        public LzwNode()
+    }
+
+    public LzwNode(long codeValue)
+    {
+        this.Code = codeValue;
+    }
+
+    public long Code { get; set; }
+
+    public int Count { get { return subNodes.Count; } }
+
+    public void SetNode(byte b, LzwNode node)
+    {
+        subNodes.Add(b, node);
+    }
+
+    public LzwNode GetNode(byte data)
+    {
+        subNodes.TryGetValue(data, out LzwNode node);
+        return node;
+    }
+
+    public LzwNode GetNode(byte[] data)
+    {
+        LzwNode current = this;
+        for (int i = 0; i < data.Length && current != null; i++)
         {
-
+            current = current.GetNode(data[i]);
         }
-
-        public LzwNode(long codeValue)
-        {
-            this.Code = codeValue;
-        }
-        
-
-        public long Code { get; set; }
-
-        public int Count { get { return subNodes.Count; } }
-
-        public void SetNode(byte b, LzwNode node)
-        {
-            subNodes.Add(b, node);
-        }
-
-        public LzwNode GetNode(byte data)
-        {
-            LzwNode node;
-            subNodes.TryGetValue(data, out node);
-            return node;
-        }
-
-        public LzwNode GetNode(byte[] data)
-        {
-            LzwNode current = this;
-            for (int i = 0; i < data.Length && current != null; i++)
-            {
-                current = current.GetNode(data[i]);
-            }
-            return current;
-        }
+        return current;
     }
 }

--- a/OcfLzw/NBitStream.cs
+++ b/OcfLzw/NBitStream.cs
@@ -5,66 +5,59 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace OcfLzw
+namespace OcfLzw;
+
+/// <summary>
+/// This is an n-bit input stream.  This means that you can read chunks of data
+/// as any number of bits, not just 8 bits like the regular input stream.Just set the
+/// number of bits that you would like to read on each call.  The default is 8.
+/// </summary>
+/// <remarks>
+/// Initialise a new input stream
+/// </remarks>
+/// <param name="inputStream">The input stream to readfrom</param>
+public class NBitStream(Stream inputStream)
 {
+    private readonly Stream inputStream = inputStream;
+    private int bitsLeftInCurrentByte;
+    private int currentByte;
+
     /// <summary>
-    /// This is an n-bit input stream.  This means that you can read chunks of data
-    /// as any number of bits, not just 8 bits like the regular input stream.Just set the
-    /// number of bits that you would like to read on each call.  The default is 8.
+    /// The number of Bits To Read on next Read(). Defaults to 8.s
     /// </summary>
-    public class NBitStream 
+    public int BitsInChunk { get; set; } = 8; // default 8 bits in the chunk
+
+    /// <summary>
+    /// Original Stream wrapped by this stream.
+    /// </summary>
+    public Stream Stream { get { return inputStream; } }
+
+    /// <summary>
+    /// This will read the next n bits from the stream and return the unsigned
+    /// value of  those bits.
+    /// </summary>
+    /// <returns>The next n bits from the stream.</returns>
+    public long Read()
     {
-        private Stream inputStream;
-        private int bitsLeftInCurrentByte;
-        private int currentByte;
-
-        /// <summary>
-        /// Initialise a new input stream
-        /// </summary>
-        /// <param name="inputStream">The input stream to readfrom</param>
-        public NBitStream(Stream inputStream)
+        long retval = 0;
+        for (int i = 0; i < BitsInChunk && retval != -1; i++)
         {
-            this.inputStream = inputStream;
-            this.BitsInChunk = 8; // default 8 bits in the chunk
-        }
-
-        /// <summary>
-        /// The number of Bits To Read on next Read(). Defaults to 8.s
-        /// </summary>
-        public int BitsInChunk { get; set; }
-
-        /// <summary>
-        /// Original Stream wrapped by this stream.
-        /// </summary>
-        public Stream Stream { get { return inputStream; } }
-
-        /// <summary>
-        /// This will read the next n bits from the stream and return the unsigned
-        /// value of  those bits.
-        /// </summary>
-        /// <returns>The next n bits from the stream.</returns>
-        public long Read()
-        {
-            long retval = 0;
-            for (int i = 0; i < BitsInChunk && retval != -1; i++)
+            if (bitsLeftInCurrentByte == 0)
             {
-                if (bitsLeftInCurrentByte == 0)
-                {
-                    currentByte = inputStream.ReadByte();
-                    bitsLeftInCurrentByte = 8;
-                }
-                if (currentByte == -1)
-                {
-                    retval = -1;
-                }
-                else
-                {
-                    retval <<= 1;
-                    retval |= ((currentByte >> (bitsLeftInCurrentByte - 1)) & 0x1);
-                    bitsLeftInCurrentByte--;
-                }
+                currentByte = inputStream.ReadByte();
+                bitsLeftInCurrentByte = 8;
             }
-            return retval;
+            if (currentByte == -1)
+            {
+                retval = -1;
+            }
+            else
+            {
+                retval <<= 1;
+                retval |= (currentByte >> (bitsLeftInCurrentByte - 1)) & 0x1;
+                bitsLeftInCurrentByte--;
+            }
         }
+        return retval;
     }
 }

--- a/OcfLzw/OcfLzw.cs
+++ b/OcfLzw/OcfLzw.cs
@@ -1,152 +1,145 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 
-namespace OcfLzw
+namespace OcfLzw;
+
+/// <summary>
+/// "OCF Compresion" is used by Cerner PowerChart. 
+/// It's basically just the LZW compression used in TIFF images.
+/// This is ported from the LZW filter from the Apache pdfbox project
+/// https://pdfbox.apache.org/.
+/// 
+/// License: http://www.apache.org/licenses/LICENSE-2.0
+/// </summary>
+/// <remarks>
+/// I like this implementation from PDFBox, but it's very heap intensive. 
+/// As I want to run this across millions of rows, the performance just isn't there.
+/// The twelve monkey's LZW Decoder: https://github.com/haraldk/TwelveMonkeys/blob/master/imageio/imageio-tiff/src/main/java/com/twelvemonkeys/imageio/plugins/tiff/LZWDecoder.java
+/// looks like it would be less painful on the heap
+/// </remarks>
+public class OcfLzw
 {
     /// <summary>
-    /// "OCF Compresion" is used by Cerner PowerChart. 
-    /// It's basically just the LZW compression used in TIFF images.
-    /// This is ported from the LZW filter from the Apache pdfbox project
-    /// https://pdfbox.apache.org/.
-    /// 
-    /// License: http://www.apache.org/licenses/LICENSE-2.0
+    /// The LZW clear table code.
     /// </summary>
-    /// <remarks>
-    /// I like this implementation from PDFBox, but it's very heap intensive. 
-    /// As I want to run this across millions of rows, the performance just isn't there.
-    /// The twelve monkey's LZW Decoder: https://github.com/haraldk/TwelveMonkeys/blob/master/imageio/imageio-tiff/src/main/java/com/twelvemonkeys/imageio/plugins/tiff/LZWDecoder.java
-    /// looks like it would be less painful on the heap
-    /// </remarks>
-    public class OcfLzw
+    const int CLEAR_TABLE = 256;
+
+    /// <summary>
+    /// The LZW end of data code.
+    /// </summary>
+    const int EOD = 257;
+
+    /// <summary>
+    /// The minimum size (in bits) of a compressed chunk
+    /// </summary>
+    const int MIN_CHUNK_SIZE = 9;
+
+
+    /// <summary>
+    /// The maximum size (in bits) of a compressed chunk
+    /// </summary>
+    const int MAX_CHUNK_SIZE = 13;
+
+    /// <summary>
+    /// The first code in the set
+    /// </summary>
+    const int FIRST_CODE = 258;
+
+    const int DICTIONARY_SIZE = 9029;
+
+    /// <summary>
+    /// Decodes the specified compressed string (ideally 8 bit chars) and returns the decompressed string
+    /// </summary>
+    /// <param name="compressed">LZW encoded string</param>
+    /// <returns>Decoded string</returns>
+    public static string Decode(string compressed)
     {
-        /// <summary>
-        /// The LZW clear table code.
-        /// </summary>
-        const int CLEAR_TABLE = 256;
+        return Encoding.Default.GetString(Decode(Encoding.Default.GetBytes(compressed)));
+    }
 
-        /// <summary>
-        /// The LZW end of data code.
-        /// </summary>
-        const int EOD = 257;
+    /// <summary>
+    /// Decodes the specified byte array
+    /// </summary>
+    /// <param name="compressed">Compressed Bytes</param>
+    /// <returns>byte array of decompressed data</returns>
+    public static byte[] Decode(byte[] compressed)
+    {
+        using var reader = new MemoryStream(compressed);
+        using var output = new MemoryStream();
+        Decode(reader, output);
+        return output.ToArray();
+    }
 
-        /// <summary>
-        /// The minimum size (in bits) of a compressed chunk
-        /// </summary>
-        const int MIN_CHUNK_SIZE = 9;
+    /// <summary>
+    /// Decodes the data in the stream with the LZW decoder
+    /// </summary>
+    /// <param name="compressedInput">Stream of compressed data</param>
+    /// <param name="output">Stream of decompressed data</param>
+    public static void Decode(Stream compressedInput, Stream output)
+    {
+        NBitStream input = new(compressedInput);
+        //int bitsInChunk = MIN_CHUNK_SIZE; // Min size
+        byte firstByte = 0;
+        input.BitsInChunk = MIN_CHUNK_SIZE;
 
+        var dic = new LzwDictionary(DICTIONARY_SIZE);
 
-        /// <summary>
-        /// The maximum size (in bits) of a compressed chunk
-        /// </summary>
-        const int MAX_CHUNK_SIZE = 13;
-
-        /// <summary>
-        /// The first code in the set
-        /// </summary>
-        const int FIRST_CODE = 258;
-
-        const int DICTIONARY_SIZE = 9029;
-
-        /// <summary>
-        /// Decodes the specified compressed string (ideally 8 bit chars) and returns the decompressed string
-        /// </summary>
-        /// <param name="compressed">LZW encoded string</param>
-        /// <returns>Decoded string</returns>
-        public static string Decode(string compressed)
+        long nextCommand;
+        while ((nextCommand = input.Read()) != EOD)
         {
-            return Encoding.Default.GetString(Decode(Encoding.Default.GetBytes(compressed)));
-        }
-
-        /// <summary>
-        /// Decodes the specified byte array
-        /// </summary>
-        /// <param name="compressed">Compressed Bytes</param>
-        /// <returns>byte array of decompressed data</returns>
-        public static byte[] Decode(byte[] compressed)
-        {
-            using (var reader = new MemoryStream(compressed))
-            using (var output = new MemoryStream())
+            if (nextCommand < 0)
             {
-                Decode(reader, output);
-                return output.ToArray();
-            }   
-        }
+                break;
+            }
 
-        /// <summary>
-        /// Decodes the data in the stream with the LZW decoder
-        /// </summary>
-        /// <param name="compressedInput">Stream of compressed data</param>
-        /// <param name="output">Stream of decompressed data</param>
-        public static void Decode(Stream compressedInput, Stream output)
-        {
-            NBitStream input = new NBitStream(compressedInput);
-            //int bitsInChunk = MIN_CHUNK_SIZE; // Min size
-            byte firstByte = 0;
-            long nextCommand = 0;
-            
-            input.BitsInChunk = MIN_CHUNK_SIZE;
-
-            var dic = new LzwDictionary(DICTIONARY_SIZE);
-
-            while ((nextCommand = input.Read()) != EOD)
+            // Do our reset
+            if (nextCommand == CLEAR_TABLE)
             {
-                if (nextCommand < 0)
+                input.BitsInChunk = MIN_CHUNK_SIZE;
+                dic = new LzwDictionary(DICTIONARY_SIZE);
+            }
+            else
+            {
+                byte[] data = dic.GetData(nextCommand);
+                if (data == null)
                 {
-                    break;
+                    dic.Visit(firstByte);
+                    data = dic.GetData(nextCommand);
+                    dic.Clearbuffer(); // clear buffer
                 }
-                
-                // Do our reset
-                if (nextCommand == CLEAR_TABLE)
+                if (data == null)
                 {
-                    input.BitsInChunk = MIN_CHUNK_SIZE;
-                    dic = new LzwDictionary(DICTIONARY_SIZE);
+                    throw new Exception("Error: data is null");
+                }
+
+                dic.Visit(data);
+
+                if (dic.GetNextCode() >= 2047)
+                {
+                    input.BitsInChunk = 12;
+                }
+                else if (dic.GetNextCode() >= 1023)
+                {
+                    input.BitsInChunk = 11;
+                }
+                else if (dic.GetNextCode() >= 511)
+                {
+                    input.BitsInChunk = 10;
                 }
                 else
                 {
-                    byte[] data = dic.GetData(nextCommand);
-                    if (data == null)
-                    {
-                        dic.Visit(firstByte);
-                        data = dic.GetData(nextCommand);
-                        dic.Clearbuffer(); // clear buffer
-                    }
-                    if (data == null)
-                    {
-                        throw new Exception("Error: data is null");
-                    }
-
-                    dic.Visit(data);
-
-                    if (dic.GetNextCode() >= 2047)
-                    {
-                        input.BitsInChunk = 12;
-                    }
-                    else if (dic.GetNextCode() >= 1023)
-                    {
-                        input.BitsInChunk = 11;
-                    }
-                    else if (dic.GetNextCode() >= 511)
-                    {
-                        input.BitsInChunk = 10;
-                    }
-                    else
-                    {
-                        input.BitsInChunk = 9;
-                    }
-
-                    firstByte = data[0];
-                    output.Write(data, 0, data.Length);
+                    input.BitsInChunk = 9;
                 }
-                
+
+                firstByte = data[0];
+                output.Write(data, 0, data.Length);
             }
-            output.Flush();
-            
-            
+
         }
+        output.Flush();
+
 
     }
+
 }

--- a/OcfLzw/OcfLzw.csproj
+++ b/OcfLzw/OcfLzw.csproj
@@ -1,57 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{B70171CA-7BB4-425A-9DCF-290D4719389D}</ProjectGuid>
+    <TargetFramework>net9.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>OcfLzw</RootNamespace>
-    <AssemblyName>OcfLzw</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
+    <AssemblyTitle>OcfLzw</AssemblyTitle>
+    <Product>OcfLzw</Product>
+    <Copyright>Copyright ©  2017</Copyright>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <FileVersion>1.0.0.0</FileVersion>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="NBitStream.cs" />
-    <Compile Include="OcfLzw.cs" />
-    <Compile Include="LzwDictionary.cs" />
-    <Compile Include="LzwNode.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/OcfLzw/Properties/AssemblyInfo.cs
+++ b/OcfLzw/Properties/AssemblyInfo.cs
@@ -1,16 +1,6 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("OcfLzw")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("OcfLzw")]
-[assembly: AssemblyCopyright("Copyright ©  2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -21,16 +11,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("b70171ca-7bb4-425a-9dcf-290d4719389d")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/OcfLzw2/LzwString.cs
+++ b/OcfLzw2/LzwString.cs
@@ -1,162 +1,150 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 
-namespace OcfLzw
+namespace OcfLzw;
+
+public class LZWString(byte value, byte firstChar, int length, LZWString previous) : IComparable<LZWString>
 {
-    public class LZWString : IComparable<LZWString>
+    /// <summary>
+    /// Empty version of this string for comparisons (though can probably use null?)
+    /// </summary>
+    internal static LZWString EMPTY = new((byte)0, (byte)0, 0, null);
+
+    private readonly LZWString previous = previous;
+
+    public int length = length;
+    public byte value = value;
+    public byte firstChar = firstChar; // Copied forward for fast access
+
+    private readonly byte[] writeBuffer = new byte[length]; // Buffer used for writing out to the stream later
+
+    public LZWString(byte code) : this(code, code, 1, null) { }
+
+    public LZWString Concatenate(byte value)
     {
-        /// <summary>
-        /// Empty version of this string for comparisons (though can probably use null?)
-        /// </summary>
-        internal static LZWString EMPTY = new LZWString((byte) 0, (byte) 0, 0, null);
-
-        private LZWString previous;
-
-        public int length;
-        public byte value;
-        public byte firstChar; // Copied forward for fast access
-
-        private byte[] writeBuffer; // Buffer used for writing out to the stream later
-
-        public LZWString(byte code) : this(code, code, 1, null) { }
-
-        public LZWString(byte value, byte firstChar, int length, LZWString previous) {
-            this.value = value;
-            this.firstChar = firstChar;
-            this.length = length;
-            writeBuffer = new byte[length];
-            this.previous = previous;
+        if (this == EMPTY)
+        {
+            return new LZWString(value);
         }
 
-        public LZWString concatenate(byte value)
-        {
-            if (this == EMPTY)
-            {
-                return new LZWString(value);
-            }
+        return new LZWString(value, this.firstChar, length + 1, this);
+    }
 
-            return new LZWString(value, this.firstChar, length + 1, this);
+    public void WriteTo(Stream buffer)
+    {
+        if (length == 0)
+        {
+            return;
         }
 
-        public void writeTo(Stream buffer)
+        if (length == 1)
         {
-            if (length == 0)
-            {
-                return;
-            }
-
-            if (length == 1)
-            {
-                buffer.WriteByte(value);
-            }
-            else
-            {
-                LZWString e = this;
-                long offset = buffer.Position;
-
-                // We're using a stream.
-                // We can't assume we're going to be able to seek it in every situation
-                // (ie we might be writing it out to a HTTP response, we can't very well go "oh wait here's some more data back here")
-                // So store the values in our small buffer and write it out to the stream.
-                for (int i = length - 1; i >= 0; i--)
-                {
-                    writeBuffer[i] = e.value;
-                    //buffer.put(offset + i, e.value);
-                    //buffer.WriteByte(e.value);
-                    e = e.previous;
-                }
-
-                //buffer.position(offset + length);
-                buffer.Write(writeBuffer, 0, length);
-            }
+            buffer.WriteByte(value);
         }
-
-        #region Overrides
-        public override int GetHashCode()
+        else
         {
-            int result = previous != null ? previous.GetHashCode() : 0;
-            result = 31 * result + length;
-            result = 31 * result + (int)value;
-            result = 31 * result + (int)firstChar;
-            return result;
-        }
-
-        /// <summary>
-        /// Checks to see if the two objects are equal
-        /// </summary>
-        /// <param name="other"></param>
-        /// <returns></returns>
-        public override bool Equals(object other)
-        {
-            if (this == other)
-            {
-                return true;
-            }
-            if (other == null || other.GetType() != this.GetType())
-            {
-                return false;
-            }
-
-            LZWString s = (LZWString)other;
-
-            return firstChar == s.firstChar &&
-                    length == s.length &&
-                    value == s.value &&
-                    previous == s.previous;
-        }
-
-        public override string ToString()
-        {
-            StringBuilder builder = new StringBuilder("ZLWString[");
-            int offset = builder.Length;
             LZWString e = this;
+            long offset = buffer.Position;
+
+            // We're using a stream.
+            // We can't assume we're going to be able to seek it in every situation
+            // (ie we might be writing it out to a HTTP response, we can't very well go "oh wait here's some more data back here")
+            // So store the values in our small buffer and write it out to the stream.
             for (int i = length - 1; i >= 0; i--)
             {
-                builder.Insert(offset, String.Format("%2x", e.value));
+                writeBuffer[i] = e.value;
+                //buffer.put(offset + i, e.value);
+                //buffer.WriteByte(e.value);
                 e = e.previous;
             }
-            builder.Append("]");
-            return builder.ToString();
+
+            //buffer.position(offset + length);
+            buffer.Write(writeBuffer, 0, length);
+        }
+    }
+
+    #region Overrides
+    public override int GetHashCode()
+    {
+        int result = previous != null ? previous.GetHashCode() : 0;
+        result = 31 * result + length;
+        result = 31 * result + (int)value;
+        result = 31 * result + (int)firstChar;
+        return result;
+    }
+
+    /// <summary>
+    /// Checks to see if the two objects are equal
+    /// </summary>
+    /// <param name="other"></param>
+    /// <returns></returns>
+    public override bool Equals(object other)
+    {
+        if (this == other)
+        {
+            return true;
+        }
+        if (other == null || other.GetType() != this.GetType())
+        {
+            return false;
         }
 
-        public int CompareTo(LZWString other)
+        LZWString s = (LZWString)other;
+
+        return firstChar == s.firstChar &&
+                length == s.length &&
+                value == s.value &&
+                previous == s.previous;
+    }
+
+    public override string ToString()
+    {
+        StringBuilder builder = new("ZLWString[");
+        int offset = builder.Length;
+        LZWString e = this;
+        for (int i = length - 1; i >= 0; i--)
         {
-            if (other == this)
-            {
-                return 0;
-            }
+            builder.Insert(offset, string.Format("%2x", e.value));
+            e = e.previous;
+        }
+        builder.Append(']');
+        return builder.ToString();
+    }
 
-            if (length != other.length)
-            {
-                return other.length - length;
-            }
-
-            if (firstChar != other.firstChar)
-            {
-                return other.firstChar - firstChar;
-            }
-
-            LZWString t = this;
-            LZWString o = other;
-
-            for (int i = length - 1; i > 0; i--)
-            {
-                if (t.value != o.value)
-                {
-                    return o.value - t.value;
-                }
-
-                t = t.previous;
-                o = o.previous;
-            }
-
+    public int CompareTo(LZWString other)
+    {
+        if (other == this)
+        {
             return 0;
         }
 
-        #endregion
+        if (length != other.length)
+        {
+            return other.length - length;
+        }
+
+        if (firstChar != other.firstChar)
+        {
+            return other.firstChar - firstChar;
+        }
+
+        LZWString t = this;
+        LZWString o = other;
+
+        for (int i = length - 1; i > 0; i--)
+        {
+            if (t.value != o.value)
+            {
+                return o.value - t.value;
+            }
+
+            t = t.previous;
+            o = o.previous;
+        }
+
+        return 0;
     }
+
+    #endregion
 }

--- a/OcfLzw2/LzwTable.cs
+++ b/OcfLzw2/LzwTable.cs
@@ -1,54 +1,50 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace OcfLzw
+namespace OcfLzw;
+
+public class LzwTable : List<LZWString>
 {
-    public class LzwTable : List<LZWString>
+    public LzwTable(int capacity) : base(capacity) // Set the initial capacity to reduce memory copies
     {
-        public LzwTable(int capacity) : base(capacity) // Set the initial capacity to reduce memory copies
+
+        for (int i = 0; i < 256; i++)
         {
-            
-            for (int i = 0; i < 256; i++)
-            {
-                base.Add(new LZWString((byte)i));
-            }
-            base.Add(null); // 256 EOD
-            base.Add(null); // 257 CLEAR_TABLE
+            base.Add(new LZWString((byte)i));
         }
+        base.Add(null); // 256 EOD
+        base.Add(null); // 257 CLEAR_TABLE
+    }
 
-               
-        public bool IsInTable(int code)
-        {
-            return code < GetNextCode();
-        }
 
-        public new void Add(LZWString lzwString)
-        {
-            // This really can never happen as we're using a List
-            if (this.GetNextCode() > this.Capacity)
-                 throw new Exception($"LZW with more than {OcfLzw2.MAX_CHUNK_SIZE} bits per code encountered (table overflow)");
-            
-            base.Add(lzwString);
+    public bool IsInTable(int code)
+    {
+        return code < GetNextCode();
+    }
 
-            // Determins the maximum code for the given bit value (ie 511 at 9 bits through to 4096 at 12 bits)
-            //var maximumCode = (1 << codeSize) - 1;
-                        
-        }
+    public new void Add(LZWString lzwString)
+    {
+        // This really can never happen as we're using a List
+        if (this.GetNextCode() > this.Capacity)
+            throw new Exception($"LZW with more than {OcfLzw2.MAX_CHUNK_SIZE} bits per code encountered (table overflow)");
 
-        public int GetNextCode()
-        {
-            //return nextCode;
-            return this.Count;
-        }
-        
-        /// <summary>
-        /// Provide some array compatiblity
-        /// </summary>
-        public int Length {  get { return this.Count; } }
+        base.Add(lzwString);
 
+        // Determins the maximum code for the given bit value (ie 511 at 9 bits through to 4096 at 12 bits)
+        //var maximumCode = (1 << codeSize) - 1;
 
     }
+
+    public int GetNextCode()
+    {
+        //return nextCode;
+        return this.Count;
+    }
+
+    /// <summary>
+    /// Provide some array compatiblity
+    /// </summary>
+    public int Length { get { return this.Count; } }
+
+
 }

--- a/OcfLzw2/NBitStream.cs
+++ b/OcfLzw2/NBitStream.cs
@@ -1,70 +1,58 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.IO;
 
-namespace OcfLzw
+namespace OcfLzw;
+
+/// <summary>
+/// This is an n-bit input stream.  This means that you can read chunks of data
+/// as any number of bits, not just 8 bits like the regular input stream.Just set the
+/// number of bits that you would like to read on each call.  The default is 8.
+/// </summary>
+/// <remarks>
+/// Initialise a new input stream
+/// </remarks>
+/// <param name="inputStream">The input stream to readfrom</param>
+public class NBitStream(Stream inputStream)
 {
+    private readonly Stream inputStream = inputStream;
+    private int bitsLeftInCurrentByte;
+    private int currentByte;
+
     /// <summary>
-    /// This is an n-bit input stream.  This means that you can read chunks of data
-    /// as any number of bits, not just 8 bits like the regular input stream.Just set the
-    /// number of bits that you would like to read on each call.  The default is 8.
+    /// The number of Bits To Read on next Read(). Defaults to 8.s
     /// </summary>
-    public class NBitStream 
+    public int BitsInChunk { get; set; } = 8; // default 8 bits in the chunk
+
+    /// <summary>
+    /// Original Stream wrapped by this stream.
+    /// </summary>
+    public Stream Stream { get { return inputStream; } }
+
+    /// <summary>
+    /// This will read the next n bits from the stream and return the unsigned
+    /// value of  those bits.
+    /// </summary>
+    /// <returns>The next n bits from the stream.</returns>
+    public long Read()
     {
-        private Stream inputStream;
-        private int bitsLeftInCurrentByte;
-        private int currentByte;
-
-        /// <summary>
-        /// Initialise a new input stream
-        /// </summary>
-        /// <param name="inputStream">The input stream to readfrom</param>
-        public NBitStream(Stream inputStream)
+        long retval = 0;
+        for (int i = 0; i < BitsInChunk && retval != -1; i++)
         {
-            this.inputStream = inputStream;
-            this.BitsInChunk = 8; // default 8 bits in the chunk
-        }
-
-        /// <summary>
-        /// The number of Bits To Read on next Read(). Defaults to 8.s
-        /// </summary>
-        public int BitsInChunk { get; set; }
-
-        /// <summary>
-        /// Original Stream wrapped by this stream.
-        /// </summary>
-        public Stream Stream { get { return inputStream; } }
-
-        /// <summary>
-        /// This will read the next n bits from the stream and return the unsigned
-        /// value of  those bits.
-        /// </summary>
-        /// <returns>The next n bits from the stream.</returns>
-        public long Read()
-        {
-            long retval = 0;
-            for (int i = 0; i < BitsInChunk && retval != -1; i++)
+            if (bitsLeftInCurrentByte == 0)
             {
-                if (bitsLeftInCurrentByte == 0)
-                {
-                    currentByte = inputStream.ReadByte();
-                    bitsLeftInCurrentByte = 8;
-                }
-                if (currentByte == -1)
-                {
-                    retval = -1;
-                }
-                else
-                {
-                    retval <<= 1;
-                    retval |= ((currentByte >> (bitsLeftInCurrentByte - 1)) & 0x1);
-                    bitsLeftInCurrentByte--;
-                }
+                currentByte = inputStream.ReadByte();
+                bitsLeftInCurrentByte = 8;
             }
-            return retval;
+            if (currentByte == -1)
+            {
+                retval = -1;
+            }
+            else
+            {
+                retval <<= 1;
+                retval |= (currentByte >> (bitsLeftInCurrentByte - 1)) & 0x1;
+                bitsLeftInCurrentByte--;
+            }
         }
+        return retval;
     }
 }

--- a/OcfLzw2/OcfLzw.cs
+++ b/OcfLzw2/OcfLzw.cs
@@ -1,185 +1,178 @@
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 
-namespace OcfLzw
+namespace OcfLzw;
+
+/// <summary>
+/// "OCF Compresion" is used by Cerner PowerChart. 
+/// It's basically just the LZW compression used in TIFF images.
+/// License: http://www.apache.org/licenses/LICENSE-2.0
+/// </summary>
+/// <remarks>
+/// This port is based on two Java Implementation of TIFF LZE. 
+/// PDFBox was the original source (https://pdfbox.apache.org/.).
+/// I've made use of it's NBitStream for reading the variable bit-widths from the stream.
+/// However PDFBox was very heap-intensive (and really didn't need the hash of a dictionary),
+/// with decompressing 1 million values taking over 1 min on an i5-4590s.
+/// As I want to run this across millions of rows, the performance just isn't there.
+/// Instead the main decoding is from the TwelveMonkeys Image IO extensions,
+/// specfically - https://github.com/haraldk/TwelveMonkeys/blob/master/imageio/imageio-tiff/src/main/java/com/twelvemonkeys/imageio/plugins/tiff/LZWDecoder.java
+/// Rather than a dictionary and node-tree, it uses a much more sensible array of LzwString, which have 
+/// (with the exception of the buffer) a static memory footprint. This reduces the number of objects created.
+/// As a result, running 1 million values on the same i5-4590s now completes within ~30 seconds.
+/// I think there's room for further optimisation, but I want to try and ensure the code remains readable.
+/// </remarks>
+public class OcfLzw2
 {
     /// <summary>
-    /// "OCF Compresion" is used by Cerner PowerChart. 
-    /// It's basically just the LZW compression used in TIFF images.
-    /// License: http://www.apache.org/licenses/LICENSE-2.0
+    /// The LZW clear table code.
     /// </summary>
-    /// <remarks>
-    /// This port is based on two Java Implementation of TIFF LZE. 
-    /// PDFBox was the original source (https://pdfbox.apache.org/.).
-    /// I've made use of it's NBitStream for reading the variable bit-widths from the stream.
-    /// However PDFBox was very heap-intensive (and really didn't need the hash of a dictionary),
-    /// with decompressing 1 million values taking over 1 min on an i5-4590s.
-    /// As I want to run this across millions of rows, the performance just isn't there.
-    /// Instead the main decoding is from the TwelveMonkeys Image IO extensions,
-    /// specfically - https://github.com/haraldk/TwelveMonkeys/blob/master/imageio/imageio-tiff/src/main/java/com/twelvemonkeys/imageio/plugins/tiff/LZWDecoder.java
-    /// Rather than a dictionary and node-tree, it uses a much more sensible array of LzwString, which have 
-    /// (with the exception of the buffer) a static memory footprint. This reduces the number of objects created.
-    /// As a result, running 1 million values on the same i5-4590s now completes within ~30 seconds.
-    /// I think there's room for further optimisation, but I want to try and ensure the code remains readable.
-    /// </remarks>
-    public class OcfLzw2
+    internal const int CLEAR_TABLE = 256;
+
+    /// <summary>
+    /// The LZW end of data code.
+    /// </summary>
+    internal const int EOD = 257;
+
+    /// <summary>
+    /// The minimum size (in bits) of a compressed chunk
+    /// </summary>
+    internal const int MIN_CHUNK_SIZE = 9;
+
+
+    /// <summary>
+    /// The maximum size (in bits) of a compressed chunk
+    /// </summary>
+    internal const int MAX_CHUNK_SIZE = 13;
+
+    /// <summary>
+    /// The first code in the set
+    /// </summary>
+    internal const int FIRST_CODE = 258;
+
+    //internal const int DICTIONARY_SIZE = 9029;
+
+    internal const int CODE_SIZE = 9; // Default code size ...
+
+    /// <summary>
+    /// Expected table size
+    /// </summary>
+    internal const int TABLE_SIZE = 1 << MAX_CHUNK_SIZE;
+
+    /// <summary>
+    /// Decodes the specified compressed string (ideally 8 bit chars) and returns the decompressed string
+    /// </summary>
+    /// <param name="compressed">LZW encoded string</param>
+    /// <returns>Decoded string</returns>
+    public static string Decode(string compressed)
     {
-        /// <summary>
-        /// The LZW clear table code.
-        /// </summary>
-        internal const int CLEAR_TABLE = 256;
+        return Encoding.Default.GetString(Decode(Encoding.Default.GetBytes(compressed)));
+    }
 
-        /// <summary>
-        /// The LZW end of data code.
-        /// </summary>
-        internal const int EOD = 257;
+    /// <summary>
+    /// Decodes the specified byte array
+    /// </summary>
+    /// <param name="compressed">Compressed Bytes</param>
+    /// <returns>byte array of decompressed data</returns>
+    public static byte[] Decode(byte[] compressed)
+    {
+        using var reader = new MemoryStream(compressed);
+        using var output = new MemoryStream();
+        Decode(reader, output);
+        return output.ToArray();
+    }
 
-        /// <summary>
-        /// The minimum size (in bits) of a compressed chunk
-        /// </summary>
-        internal const int MIN_CHUNK_SIZE = 9;
+    /// <summary>
+    /// Decodes the data in the stream with the LZW decoder
+    /// </summary>
+    /// <param name="compressedInput">Stream of compressed data</param>
+    /// <param name="output">Stream of decompressed data</param>
+    public static void Decode(Stream compressedInput, Stream output)
+    {
+        NBitStream input = new(compressedInput);
+
+        //byte firstByte = 0;
+        long nextCommand = 0;
+
+        long lastCommand = -1; // CLEAR_TABLE;
+
+        int earlyChange = 1;
+
+        LzwTable table = new(TABLE_SIZE);
+
+        // The input needs the bits in chunk set properly to read the data
+        input.BitsInChunk = MIN_CHUNK_SIZE;
 
 
-        /// <summary>
-        /// The maximum size (in bits) of a compressed chunk
-        /// </summary>
-        internal const int MAX_CHUNK_SIZE = 13;
-
-        /// <summary>
-        /// The first code in the set
-        /// </summary>
-        internal const int FIRST_CODE = 258;
-
-        //internal const int DICTIONARY_SIZE = 9029;
-
-        internal const int CODE_SIZE = 9; // Default code size ...
-
-        /// <summary>
-        /// Expected table size
-        /// </summary>
-        internal const int TABLE_SIZE = 1 << MAX_CHUNK_SIZE;
-
-        /// <summary>
-        /// Decodes the specified compressed string (ideally 8 bit chars) and returns the decompressed string
-        /// </summary>
-        /// <param name="compressed">LZW encoded string</param>
-        /// <returns>Decoded string</returns>
-        public static string Decode(string compressed)
+        while ((nextCommand = input.Read()) != EOD)
         {
-            return Encoding.Default.GetString(Decode(Encoding.Default.GetBytes(compressed)));
-        }
-
-        /// <summary>
-        /// Decodes the specified byte array
-        /// </summary>
-        /// <param name="compressed">Compressed Bytes</param>
-        /// <returns>byte array of decompressed data</returns>
-        public static byte[] Decode(byte[] compressed)
-        {
-            using (var reader = new MemoryStream(compressed))
-            using (var output = new MemoryStream())
+            if (nextCommand < 0)
+                break; // EOF?
+            // Do our reset
+            if (nextCommand == CLEAR_TABLE)
             {
-                Decode(reader, output);
-                return output.ToArray();
-            }   
-        }
-
-        /// <summary>
-        /// Decodes the data in the stream with the LZW decoder
-        /// </summary>
-        /// <param name="compressedInput">Stream of compressed data</param>
-        /// <param name="output">Stream of decompressed data</param>
-        public static void Decode(Stream compressedInput, Stream output)
-        {
-            NBitStream input = new NBitStream(compressedInput);
-            
-            //byte firstByte = 0;
-            long nextCommand = 0;
-
-            long lastCommand = -1; // CLEAR_TABLE;
-
-            int earlyChange = 1;
-
-            LzwTable table = new LzwTable(TABLE_SIZE);
-            
-            // The input needs the bits in chunk set properly to read the data
-            input.BitsInChunk = MIN_CHUNK_SIZE;
-
-           
-            while ((nextCommand = input.Read()) != EOD)
+                input.BitsInChunk = MIN_CHUNK_SIZE;
+                table = new LzwTable(TABLE_SIZE);
+                lastCommand = -1;
+            }
+            else
             {
-                if (nextCommand < 0)
-                    break; // EOF?
-                // Do our reset
-                if (nextCommand == CLEAR_TABLE)
+                //if (table[lastCommand] == null)
+                //{
+                //    throw new Exception(String.Format("Corrupted LZW: code {0} (table size: {1})", lastCommand, table.Length));
+                //}
+
+                // Check if the command is already in the table
+                // We could use a dictionary here, but I don't think we need the extra overhead of a hash
+                if (nextCommand < table.Count)
                 {
-                    input.BitsInChunk = MIN_CHUNK_SIZE;
-                    table = new LzwTable(TABLE_SIZE);
-                    lastCommand = -1;
+                    table[(int)nextCommand].WriteTo(output);
+
+                    if (lastCommand != -1)
+                    {
+                        table.Add(table[(int)lastCommand].Concatenate(table[(int)nextCommand].firstChar));
+                    }
                 }
                 else
                 {
-                    //if (table[lastCommand] == null)
-                    //{
-                    //    throw new Exception(String.Format("Corrupted LZW: code {0} (table size: {1})", lastCommand, table.Length));
-                    //}
+                    LZWString outString = table[(int)lastCommand].Concatenate(table[(int)lastCommand].firstChar);
 
-                    // Check if the command is already in the table
-                    // We could use a dictionary here, but I don't think we need the extra overhead of a hash
-                    if (nextCommand < table.Count)
-                    {
-                        table[(int)nextCommand].writeTo(output);
-
-                        if (lastCommand != -1)
-                        {
-                            table.Add(table[(int)lastCommand].concatenate(table[(int)nextCommand].firstChar));
-                        }
-                    }
-                    else
-                    {
-                        LZWString outString = table[(int)lastCommand].concatenate(table[(int)lastCommand].firstChar);
-
-                        outString.writeTo(output);
-                        table.Add(outString);
-                    }
-
-                    
-
-                    // The input needs the bits in chunk set properly to read the data
-                    if (table.GetNextCode() >= 4096 - earlyChange)
-                    {
-                        input.BitsInChunk = 13;
-                    }
-                    else
-                    if (table.GetNextCode() >= 2048 - earlyChange)
-                    {
-                        input.BitsInChunk = 12;
-                    }
-                    else if (table.GetNextCode() >= 1024 - earlyChange)
-                    {
-                        input.BitsInChunk = 11;
-                    }
-                    else if (table.GetNextCode() >= 512 - earlyChange)
-                    {
-                        input.BitsInChunk = 10;
-                    }
-                    else
-                    {
-                        input.BitsInChunk = 9;
-                    }
-
-                    lastCommand = nextCommand;
+                    outString.WriteTo(output);
+                    table.Add(outString);
                 }
 
-            } // while end
-                       
 
-            output.Flush();
-        }
 
+                // The input needs the bits in chunk set properly to read the data
+                if (table.GetNextCode() >= 4096 - earlyChange)
+                {
+                    input.BitsInChunk = 13;
+                }
+                else
+                if (table.GetNextCode() >= 2048 - earlyChange)
+                {
+                    input.BitsInChunk = 12;
+                }
+                else if (table.GetNextCode() >= 1024 - earlyChange)
+                {
+                    input.BitsInChunk = 11;
+                }
+                else if (table.GetNextCode() >= 512 - earlyChange)
+                {
+                    input.BitsInChunk = 10;
+                }
+                else
+                {
+                    input.BitsInChunk = 9;
+                }
+
+                lastCommand = nextCommand;
+            }
+
+        } // while end
+
+
+        output.Flush();
     }
+
 }

--- a/OcfLzw2/OcfLzw2.csproj
+++ b/OcfLzw2/OcfLzw2.csproj
@@ -1,57 +1,12 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{76D25C7F-BD56-44E6-87ED-FE866EA63ACE}</ProjectGuid>
+    <TargetFramework>net9.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>OcfLzw</RootNamespace>
-    <AssemblyName>OcfLzw2</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
+    <AssemblyTitle>OcfLzw</AssemblyTitle>
+    <Product>OcfLzw</Product>
+    <Copyright>Copyright ©  2017</Copyright>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <FileVersion>1.0.0.0</FileVersion>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="LzwString.cs" />
-    <Compile Include="LzwTable.cs" />
-    <Compile Include="NBitStream.cs" />
-    <Compile Include="OcfLzw.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/OcfLzw2/Properties/AssemblyInfo.cs
+++ b/OcfLzw2/Properties/AssemblyInfo.cs
@@ -1,16 +1,6 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("OcfLzw")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("OcfLzw")]
-[assembly: AssemblyCopyright("Copyright ©  2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -21,16 +11,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("b70171ca-7bb4-425a-9dcf-290d4719389d")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]


### PR DESCRIPTION
Thank you for the repo @pgodwin . I used this code in one of our projects and it was of great help. While doing so, I had to migrate to the latest version of dotnet. I wondered if it would be beneficial to anyone using this repo. 

Please review if you think this makes sense, or feel free to reject the PR.

All unit test runs are successful 

### Here is a summary of the changes

- Removed legacy MSBuild properties, explicit system references, and `AssemblyInfo.cs` files, consolidating metadata into project files.

- Modernized codebase with C# 9.0+ features, including `record`-style constructors, `new()` initializations, and expression-bodied members.

- Updated test projects dependencies (`MSTest.TestAdapter`, `MSTest.TestFramework`, `Microsoft.NET.Test.Sdk`) and enabled implicit usings and nullable reference types.

- Performed general cleanup, unused directives, and updated to consistent casing for method names.